### PR TITLE
updated export function block

### DIFF
--- a/templates/module.build.ps1
+++ b/templates/module.build.ps1
@@ -103,6 +103,7 @@ task Publish {
 task PublishNuget {
     $newVersion = New-Object version -ArgumentList 1, 0, 0, $BuildNumber
     "Version is $newVersion"
+
     $PublicScriptPath = "$ModulePath\Public"
     $psFilter = "*.ps1"
     $functions = ( Get-ChildItem -Path $PublicScriptPath -Filter $psFilter -Recurse -ErrorAction SilentlyContinue | Select-String -Pattern "function" )
@@ -112,11 +113,12 @@ task PublishNuget {
         $x = $x -replace ' {'
         $exportFunctions += $x
     }
+    
     Update-ModuleManifest -Path $ModulePath\$ModuleName.psd1 -ModuleVersion $newVersion -FunctionsToExport $exportFunctions
 
     $t = [xml] (Get-Content .\$ModuleName.nuspec)
     $t.package.metadata.version = $newVersion.ToString()
     $t.Save(".\$ModuleName.nuspec")
 
-    #nuget pack $ModuleName.nuspec -basepath $ModulePath -NoPackageAnalysis -outputdirectory $ENV:Build_ArtifactStagingDirectory
+    nuget pack $ModuleName.nuspec -basepath $ModulePath -NoPackageAnalysis -outputdirectory $ENV:Build_ArtifactStagingDirectory
 }


### PR DESCRIPTION
instead of using the single file, single function methodology, this allows multiple functions per file to be captured and added to the "Update-ModuleManifest" cmdlet.

May need a cleaner / more refined way to format the string but works perfectly if the code is correctly formatted.