### PR TITLE
PublishCodeCoverageResults - breaking change workaround

### DIFF
--- a/templates/azure-pipelines.yml
+++ b/templates/azure-pipelines.yml
@@ -92,4 +92,5 @@ if ($PLASTER_PARAM_Artifact -eq 'Yes') {
   inputs:
     codeCoverageTool: JaCoCo
     summaryFileLocation: "**/CodeCoverageResults*.xml"
+    pathToSources: "$(System.DefaultWorkingDirectory)\<%=$PLASTER_PARAM_ModuleName%>"
     failIfCoverageEmpty: false


### PR DESCRIPTION
PublishCodeCoverageResults now requires an additional parameter to work with JaCoCo. See below issue - I have implemented the fix proposed by karanjitsingh:

https://github.com/microsoft/azure-pipelines-tasks/issues/10212